### PR TITLE
Update cofhejs version

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -23,7 +23,7 @@
     "@uniswap/v2-sdk": "~4.6.1",
     "blo": "~1.2.0",
     "burner-connector": "0.0.14",
-    "cofhejs": "^0.3.0",
+    "cofhejs": "0.3.1-alpha.0",
     "daisyui": "5.0.9",
     "kubo-rpc-client": "~5.0.2",
     "next": "~15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,7 +3566,7 @@ __metadata:
     bgipfs: ~0.0.12
     blo: ~1.2.0
     burner-connector: 0.0.14
-    cofhejs: ^0.3.0
+    cofhejs: 0.3.1-alpha.0
     daisyui: 5.0.9
     eslint: ~9.23.0
     eslint-config-next: ~15.2.3
@@ -7000,6 +7000,24 @@ __metadata:
     ethers: ^6.10.0
     hardhat: ^2.11.0
   checksum: 41be1c82622d7bfebcf056012e61f5d2d314db9dea4e108a09c6c83bf9230924638b7c9419a6b9a0fe5000f16584d299e0823fdab7dc35b8812930ac47ac9366
+  languageName: node
+  linkType: hard
+
+"cofhejs@npm:0.3.1-alpha.0":
+  version: 0.3.1-alpha.0
+  resolution: "cofhejs@npm:0.3.1-alpha.0"
+  dependencies:
+    "@types/node": ^20.0.0
+    idb-keyval: ^6.2.1
+    immer: ^10.1.1
+    node-tfhe: 0.11.1
+    tfhe: 0.11.1
+    tweetnacl: ^1.0.3
+    tweetnacl-util: ^0.15.1
+    type-fest: ^4.26.1
+    zod: ^3.23.8
+    zustand: ^5.0.1
+  checksum: b00e6a9a433ff991d56e2a4eaa292e25828d85b2f2a295c1fb7ea93709d18fb2c72432646239d82b5274fad8c60d5eb9e4d01869e0ac4605872eb2dc7871b473
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix encrypting inputs error on testnet
Update cofhejs version from 0.3.0 -> 0.3.1-alpha.0